### PR TITLE
Only install futures for python < 3.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ VERSION = '0.1.1'
 
 # What packages are required for this module to be executed?
 REQUIRED = [
-    'futures'
+    "futures; python_version<'3.2'"
     # 'requests', 'maya', 'records',
 ]
 


### PR DESCRIPTION
I encountered a python-syntax issue when installing `background` with Python 3.6, that I traced back to the use of `futures`, an unnecessary package for Python 3.2+.
